### PR TITLE
small performance patch

### DIFF
--- a/LLVMInsTrim.cpp
+++ b/LLVMInsTrim.cpp
@@ -31,8 +31,8 @@ namespace {
       return generator() % 65536;
     }
 
- protected:
-  uint32_t function_minimum_size = 1;
+  protected:
+    uint32_t MinimumFunctionSize = 1;
 
   public:
     static char ID;
@@ -54,7 +54,7 @@ namespace {
         LoopHeadOpt = true;
       }
       if (getenv("SKIPSINGLEBLOCK")) {
-        function_minimum_size = 2;
+        MinimumFunctionSize = 2;
       }
       if (LoopHeadOpt) {
         MarkSetOpt = true;
@@ -78,7 +78,7 @@ namespace {
       for (Function &F : M) {
         // external functions have size 0 and can not be instrumented.
         // functions with only one basic block make no sense to intrument.
-        if (F.size() < function_minimum_size) {
+        if (F.size() < MinimumFunctionSize) {
           continue;
         }
 

--- a/LLVMInsTrim.cpp
+++ b/LLVMInsTrim.cpp
@@ -31,6 +31,9 @@ namespace {
       return generator() % 65536;
     }
 
+ protected:
+  uint32_t function_minimum_size = 1;
+
   public:
     static char ID;
     InsTrim() : ModulePass(ID), generator(0) {}
@@ -49,6 +52,9 @@ namespace {
       }
       if (getenv("LOOPHEAD")) {
         LoopHeadOpt = true;
+      }
+      if (getenv("SKIPSINGLEBLOCK")) {
+        function_minimum_size = 2;
       }
       if (LoopHeadOpt) {
         MarkSetOpt = true;
@@ -72,7 +78,7 @@ namespace {
       for (Function &F : M) {
         // external functions have size 0 and can not be instrumented.
         // functions with only one basic block make no sense to intrument.
-        if (F.size() < 2) {
+        if (F.size() < function_minimum_size) {
           continue;
         }
 

--- a/LLVMInsTrim.cpp
+++ b/LLVMInsTrim.cpp
@@ -70,7 +70,9 @@ namespace {
       unsigned total_hs = 0;
 
       for (Function &F : M) {
-        if (!F.size()) {
+        // external functions have size 0 and can not be instrumented.
+        // functions with only one basic block make no sense to intrument.
+        if (F.size() < 2) {
           continue;
         }
 

--- a/README.md
+++ b/README.md
@@ -40,4 +40,11 @@ With `Instrim-Approx`
 ```sh
 MARKSET=1 LOOPHEAD=1 afl-2.52b/afl-clang-fast [compilation options, your target ...]
 ```
+### Skip single block functions
+The following is recommendable for C/C++ targets that are not using vtables or similar techniques:
+```sh
+MARKSET=1 SKIPSINGLEBLOCK=1 afl-2.52b/afl-clang-fast [compilation options, your target ...]
+```
+
+## Finally
 Then you can use AFL with LLVM mode to fuzz those instrumented binaries.


### PR DESCRIPTION
simple patch: do not instrument functions that only have one basic block. It just pollutes the map.
if there is a decision to call that function it is in the callee and therefore covered.