### PR TITLE
 Instrument exit blocks when there is an empty path.

### DIFF
--- a/LLVMInsTrim.cpp
+++ b/LLVMInsTrim.cpp
@@ -125,12 +125,6 @@ namespace {
             }
           }
 
-          auto *EBB = &F.getEntryBlock();
-          if (succ_begin(EBB) == succ_end(EBB)) {
-            MS.insert(EBB);
-            total_rs += 1;
-          }
-
           for (BasicBlock &BB : F) {
             if (MS.find(&BB) == MS.end()) {
               continue;

--- a/MarkNodes.cpp
+++ b/MarkNodes.cpp
@@ -311,16 +311,16 @@ void MarkVertice(Function *F) {
     t_Succ[i].clear();
     t_Pred[i].clear();
   }
+
+  // Always instruments the function entry block.
+  Marked.insert(s);
+
   timeStamp = 0;
   uint32_t t = 0;
-  //MarkSubGraph(s, t);
-  //return;
-
   while( s != t ) {
     MarkSubGraph(DominatorTree::idom[t], t);
     t = DominatorTree::idom[t];
   }
-
 }
 
 // return {marked nodes}


### PR DESCRIPTION
The original algorithm will see the empty path as a distinguishable unique path.

For example: In the following CFG, the algorithm will initial the entry with `mark (0)`, then it will find there are 2 `mark (0)` coming from the predecessors of `block D`, so it will create a new `mark (1)`. On the exit block, the predecessors are two different marks, so it won't be marked (instrumented).

![Untitled Diagram](https://user-images.githubusercontent.com/2104162/76266982-a5a90280-623f-11ea-99f8-18f648f49a67.png)

However, the path of `mark (0)` is actually an empty path without any mark. Although an empty path is distinguishable with any other paths with marks, the fuzzer won't receive any signal if there is no mark (instrumentation) on a path.

This PR changes the marking algorithm, so it instrument function exit blocks when there is an empty path, which should address the issue #4.

Here are the number of instrumented blocks on libxml2-v2.9.10:
| Method | # of instrumented blocks |
|------------|--------------------------------|
| Full instrumentation | 68932
| Original marking algorithm | 16370
| Marking algorithm with this patch | 17264